### PR TITLE
Add container CI job

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,45 @@
+name: Build Container Image
+
+on:
+  push:
+    branches:
+      - main
+      - build-test
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate container image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}/siwe-express-example
+          tags: |
+            type=sha,enable=true,priority=100,prefix=,suffix=,format=long
+            # if is in MAIN branch, also tag as latest
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Log in to Container Image Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Containerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CI_COMMIT_SHA=${{ github.sha }}


### PR DESCRIPTION
Adds a CI job that builds the siwe example web app container image, tagged with the source git sha.